### PR TITLE
fix two serializations bug from impl tree

### DIFF
--- a/macros/src/module.rs
+++ b/macros/src/module.rs
@@ -553,19 +553,12 @@ pub fn module(args: TokenStream, input: TokenStream) -> TokenStream {
                 let inner_key = &inner_key.to_string()[2..];
 
 
-                let mut key_hex_decode = abcf::hex::decode(inner_key)
+                let mut key_vec = abcf::hex::decode(inner_key)
                     .map_err(|e|{
                     abcf::log::debug!("hex::decode:{}",e.to_string());
                     abcf::ModuleError::new(#name,
                         abcf::Error::QueryPathFormatError)
                 })?;
-
-                let key_vec = if key_hex_decode[0] == 34 && key_hex_decode[key_hex_decode.len()-1] == 34 {
-                    &key_hex_decode[1..key_hex_decode.len()-1]
-                } else {
-                    return Err(abcf::ModuleError::new(#name,
-                        abcf::Error::QueryPathFormatError));
-                };
 
                 match store_name {
                     #(#stateless_tree_match_arms,)*
@@ -784,21 +777,12 @@ pub fn module(args: TokenStream, input: TokenStream) -> TokenStream {
                     error: abcf::Error::QueryPathFormatError,
                 })?;
 
-                let mut key_hex_decode = abcf::hex::decode(inner_key)
+                let mut key_vec = abcf::hex::decode(inner_key)
                     .map_err(|e|{
                     abcf::log::debug!("hex::decode:{}",e.to_string());
                     abcf::ModuleError::new(#name,
                         abcf::Error::QueryPathFormatError)
                 })?;
-
-                let key_vec = if key_hex_decode[0] == 34 && key_hex_decode[key_hex_decode.len()-1] == 34 {
-                    &key_hex_decode[1..key_hex_decode.len()-1]
-                } else {
-                    return Err(abcf::ModuleError::new(#name,
-                        abcf::Error::QueryPathFormatError));
-                };
-
-
 
                 match store_name {
                     #(#stateful_tree_match_arms,)*

--- a/macros/src/module.rs
+++ b/macros/src/module.rs
@@ -305,11 +305,14 @@ pub fn module(args: TokenStream, input: TokenStream) -> TokenStream {
                     let target_field_ident_str = target_field.ident.clone().unwrap().to_string();
                     let stateless_tree_arm: Arm = parse_quote!(#target_field_ident_str => {
                             let mut ss = self.#target_field_ident.clone();
-                            ss.rollback(height)
-                                .map_err(|_|abcf::ModuleError {
-                                    namespace: String::from(#name),
-                                    error: abcf::Error::QueryPathFormatError,
-                                })?;
+
+                            if height > 0 {
+                                ss.rollback(height)
+                                    .map_err(|_|abcf::ModuleError {
+                                        namespace: String::from(#name),
+                                        error: abcf::Error::QueryPathFormatError,
+                                    })?;
+                            }
 
                             let v = ss.tree_get(&key_vec.to_vec())
                                 .map_err(|_|abcf::ModuleError {
@@ -356,11 +359,14 @@ pub fn module(args: TokenStream, input: TokenStream) -> TokenStream {
                     let target_field_ident_str = target_field.ident.clone().unwrap().to_string();
                     let stateful_tree_arm: Arm = parse_quote!(#target_field_ident_str => {
                             let mut ss = self.#target_field_ident.clone();
-                            ss.rollback(height)
-                                .map_err(|_|abcf::ModuleError {
-                                    namespace: String::from(#name),
-                                    error: abcf::Error::QueryPathFormatError,
-                                })?;
+
+                            if height > 0 {
+                                ss.rollback(height)
+                                    .map_err(|_|abcf::ModuleError {
+                                        namespace: String::from(#name),
+                                        error: abcf::Error::QueryPathFormatError,
+                                    })?;
+                            }
 
                             let v = ss.tree_get(&key_vec.to_vec())
                                 .map_err(|_|abcf::ModuleError {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31642966/147190913-74608a23-f6a8-401d-ad91-9f4415782d84.png)

previously I thought the data was passed through two serializations, but I misunderstood and only one serialization was done

for example
original "2" encode 223222 ---> stateless/XXX/XXX/ox223222
now 2 encode 32 --->stateless/XXX/XXX/ox32

So it only needs to be serialized once, and I only use deserialization once
